### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/footnotes-es6.js
+++ b/assets/js/footnotes-es6.js
@@ -46,7 +46,7 @@ class Footnotes {
 			this.closeNote( me );
 		}.bind( this ));
 
-		popup.innerHTML = me.getAttribute( 'data-note' );
+		popup.textContent = me.getAttribute( 'data-note' );
 
 		setTimeout( function() {
 
@@ -74,7 +74,7 @@ class Footnotes {
 	spawnPlacebo( note, ref, id ) {
 
 		var placebo = document.createElement( 'span' ),
-			content = note.children[0].innerHTML,
+			content = note.children[0].textContent,
 			it = this;
 
 		placebo.setAttribute( 'data-note', content );


### PR DESCRIPTION
Potential fix for [https://github.com/zhaoda/zhaoda.github.io/security/code-scanning/2](https://github.com/zhaoda/zhaoda.github.io/security/code-scanning/2)

In general, to fix this issue you must ensure that text taken from the DOM is not later interpreted as HTML unless you have strong guarantees it’s safe. Here, that means avoiding the pattern: DOM `innerHTML` → attribute (`data-note`) → `innerHTML` again. Instead, store plain text (or already-escaped/encoded text) in the `data-note` attribute, and when opening the popup, assign it via `textContent` (or a safe equivalent) rather than `innerHTML`. This prevents meta-characters from being treated as markup.

The minimal, behavior-preserving change within the shown code is:

1. In `spawnPlacebo`, replace `note.children[0].innerHTML` with the plain text `note.children[0].textContent` when populating `content`, so that `data-note` holds text, not HTML.
2. In `openNote`, replace `popup.innerHTML = me.getAttribute('data-note');` with `popup.textContent = me.getAttribute('data-note');`, so the popup renders that text literally rather than parsing it as HTML.

These edits are both in `assets/js/footnotes-es6.js`:
- Around line 77 in `spawnPlacebo`.
- Around line 49 in `openNote`.

No new methods are needed, and the DOM APIs used (`textContent`) are standard; no imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
